### PR TITLE
Use same comfyui as comfystream, single env

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,23 +9,24 @@
             "type": "debugpy",
             "request": "launch",
             "cwd": "/ComfyUI",
-            "program": "main.py",
-            "purpose": ["debug-in-terminal"],
-            "env": {
-                "PYDEVD_DISABLE_FILE_VALIDATION": "1"
-            },
+            "program":"/miniconda3/envs/comfystream/bin/comfyui",
             "args": [
                 "--listen",
                 "--disable-cuda-malloc",
+                "--front-end-version=Comfy-Org/ComfyUI_frontend@latest"
             ],
-            "python": "/miniconda3/envs/comfyui/bin/python"
+            "env": {
+                "PYDEVD_DISABLE_FILE_VALIDATION": "1"
+            },
+            "python": "/miniconda3/envs/comfystream/bin/python"
         },
         {
             "name": "Run ComfyStream",
             "type": "debugpy",
             "request": "launch",
-            "cwd": "/comfystream/server",
-            "program": "app.py",
+            "cwd": "/comfystream",
+            "program": "server/app.py",
+            "console": "integratedTerminal",
             "args": [
                 "--workspace=/ComfyUI",
                 "--media-ports=5678",
@@ -33,10 +34,13 @@
                 "--port=8888",
                 "--log-level=DEBUG",
             ],
+            "env": {
+                "PYDEVD_DISABLE_FILE_VALIDATION": "1"
+            },
             "python": "/miniconda3/envs/comfystream/bin/python"
         },
         {
-            "name": "Run ComfyStream UI (Node.js)",
+            "name": "Run ComfyStream UI",
             "type": "node",
             "request": "launch",
             "cwd": "/comfystream/ui",
@@ -54,12 +58,11 @@
         },
     ], "compounds": [
         {
-            "name": "Run ComfyStream and UI",
+            "name": "Run ComfyStream & UI",
             "type": "composite",
-            "stopAll": true,
             "configurations": [
                 "Run ComfyStream",
-                "Run ComfyStream UI (Node.js)"
+                "Run ComfyStream UI"
             ]
         }
     ]

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -16,10 +16,11 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 
 ENV PATH="/miniconda3/bin:${PATH}"
 RUN eval "$(/miniconda3/bin/conda shell.bash hook)"
-RUN conda create -n comfyui python=3.11 -y
+RUN conda install ffmpeg -y
+RUN conda create -n comfystream python=3.11 -y
 
 # Clone ComfyUI
-RUN git clone https://github.com/comfyanonymous/ComfyUI.git /ComfyUI
+RUN git clone https://github.com/hiddenswitch/ComfyUI.git /ComfyUI
 
 # Copy comfystream to the container
 COPY . /comfystream
@@ -29,19 +30,20 @@ COPY ./nodes/ /ComfyUI/custom_nodes/
 COPY ./workflows/ui* /ComfyUI/user/default/workflows/examples
 
 # Install custom nodes
-RUN conda run -n comfyui pip install aiortc aiohttp requests tqdm pyyaml
-RUN conda run -n comfyui --cwd /comfystream python src/comfystream/scripts/setup_nodes.py --workspace /ComfyUI
-RUN conda create -n comfystream --clone comfyui
-RUN conda run -n comfyui --cwd /ComfyUI pip install -r requirements.txt
+RUN conda run -n comfystream pip install aiortc aiohttp requests tqdm pyyaml
+RUN conda run -n comfystream --cwd /ComfyUI pip install -r requirements.txt
 
 # Install ComfyStream requirements
 RUN conda run -n comfystream --cwd /comfystream pip install -r requirements.txt
-RUN conda run -n comfystream --cwd /comfystream pip install .
-RUN conda run -n comfystream --cwd /comfystream python install.py --workspace /ComfyUI
+RUN conda run -n comfystream --cwd /comfystream pip install -e .
+RUN conda run -n comfystream --cwd /comfystream python src/comfystream/scripts/setup_nodes.py --workspace /ComfyUI
 RUN conda run -n comfystream pip install --upgrade tensorrt-cu12-bindings tensorrt-cu12-libs
 
 # # Configure no environment activation by default
 RUN conda config --set auto_activate_base false
 RUN conda init bash
+
+# Clean pip cache to reduce image size
+RUN pip cache purge
 
 WORKDIR /comfystream


### PR DESCRIPTION
This change uses the same [ComfyUI version](https://github.com/hiddenswitch/ComfyUI.git) as ComfyStream so a single python environment can be be used. The latest UI is downloaded when ComfyUI is started with the launch config. 

- Docker build will now break in case of setup_nodes failure
- Reduces docker image size from 45GB to 31GB
- 

