### PR TITLE
Update readme documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repo also includes a WebRTC server and UI that uses comfystream to support 
 
 Refer to [.devcontainer/README.md](.devcontainer/README.md) to setup ComfyStream in a devcontainer using a pre-configured ComfyUI docker environment.
 
-For other installation options, refer to [Install ComfyUI and ComfyStream](https://pipelines.livepeer.org/docs/technical/install/local-testing) in the Livepeer pipelines documentation.
+For other installation options, refer to [Install ComfyUI and ComfyStream](https://docs.comfystream.org/technical/get-started/install) in the ComfyStream documentation.
 
 For additional information, refer to the remaining sections below.
 
@@ -35,7 +35,7 @@ For additional information, refer to the remaining sections below.
 
 You can quickly deploy ComfyStream using the docker image `livepeer/comfystream`
 
-Refer to the documentation at [https://pipelines.livepeer.org/docs/technical/getting-started/install-comfystream](https://pipelines.livepeer.org/docs/technical/getting-started/install-comfystream) for instructions to run locally or on a remote server.
+Refer to the documentation at [https://docs.comfystream.org/technical/get-started/install](https://docs.comfystream.org/technical/get-started/install) for instructions to run locally or on a remote server.
 
 #### RunPod
 


### PR DESCRIPTION
Update `README.md` links from `pipelines.livepeer.org` to `docs.comfystream.org` to reflect the new documentation domain.

---
[Slack Thread](https://elitecodesolutions.slack.com/archives/C060RTM45/p1758735769511189?thread_ts=1758735769.511189&cid=C060RTM45)

<a href="https://cursor.com/background-agent?bcId=bc-dd0a42b5-e00a-47bf-a3e0-04a19e2345b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd0a42b5-e00a-47bf-a3e0-04a19e2345b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

